### PR TITLE
Fix reduceItems mutation bug

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -5,6 +5,7 @@ import {
   hasSize,
   includesItem,
   noneItems,
+  reduceItems,
   someItems,
 } from '../src/utils/array-utils.js';
 import { even, greaterThan, lessThan, withinBound } from '../src/utils/number-utils.js';
@@ -49,5 +50,15 @@ describe('predicates', () => {
     expect(
       someItems(even())
     ).toBeTruthy()
+  });
+
+  it('reduceItems should not mutate array when initial value is omitted', () => {
+    const numbers = [1, 2, 3];
+    const sumEqualsSix = reduceItems<number, number>(
+      equalTo(6),
+      (acc, current) => acc + current
+    );
+    expect(sumEqualsSix.test(numbers)).toBeTruthy();
+    expect(numbers).toEqual([1, 2, 3]);
   });
 });

--- a/src/utils/array-utils.ts
+++ b/src/utils/array-utils.ts
@@ -67,13 +67,18 @@ export function reduceItems<T, U>(
   initialValue?: U,
 ): Predicate<Array<T>> {
   return Predicate.from<Array<T>, U>((value: Array<T>) => {
+    let startValue: U;
+    let remaining: Array<T> = value;
     if (initialValue === undefined || initialValue === null) {
       if (value.length > 0) {
-        initialValue = value.shift() as unknown as U;
+        startValue = value[0] as unknown as U;
+        remaining = value.slice(1);
       } else {
         throw Error('No initialValue provided and array is empty');
       }
+    } else {
+      startValue = initialValue;
     }
-    return value.reduce<U>(reducer, initialValue);
+    return remaining.reduce<U>(reducer, startValue);
   }, reducedPredicate);
 }


### PR DESCRIPTION
## Summary
- prevent `reduceItems` from mutating its input array
- test that `reduceItems` leaves arrays unchanged when no initial value is provided

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fdbda77e483318868068657ed729b