### PR TITLE
Fix missing test invocation

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -47,7 +47,7 @@ describe('predicates', () => {
 
   it('should test someItems(even())', () => {
     expect(
-      someItems(even())
+      someItems(even()).test(arr)
     ).toBeTruthy()
   });
 });


### PR DESCRIPTION
## Summary
- call `.test(arr)` when testing `someItems(even())`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fdca375e4833191e4324df35f175f