### PR TITLE
Fix TypeScript capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-Object-oriented, lazy & complex predicate builder for typescript
+Object-oriented, lazy & complex predicate builder for TypeScript

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ts-predicate",
   "version": "0.0.1",
-  "description": "Predicate Builder in Typescript",
+  "description": "Predicate Builder in TypeScript",
   "type": "module",
   "engines": {
     "node": ">= 18.12 <19"


### PR DESCRIPTION
## Summary
- fix capitalization of TypeScript in README
- keep package description consistent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fdd6e2de883319bcac1b9389de219