### PR TITLE
Fix typo in test description

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -39,7 +39,7 @@ describe('predicates', () => {
     ).toBeTruthy();
   });
 
-  it('should test everyItem(withinBound))', () => {
+  it('should test everyItem(withinBound)', () => {
     expect(
       everyItem(withinBound(0, 10)).test(arr)
     ).toBeTruthy()


### PR DESCRIPTION
## Summary
- fix stray ')' in everyItem test title

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fdd7895388331a3461571196d463d